### PR TITLE
Added function to mark colored notes as editorial ficta

### DIFF
--- a/massage/analyze/staves.py
+++ b/massage/analyze/staves.py
@@ -100,4 +100,4 @@ def staff_role(s):
     elif 'ignore' in s.lower():
         return IGNORED
     else:
-        return 'UNKNOWN'
+        return ORIGINAL_OR_UNKNOWN

--- a/massage/constants.py
+++ b/massage/constants.py
@@ -11,13 +11,14 @@ ORIG = 'orig'
 REG = 'reg'
 LONGA = 'long'
 
-# For alernate reading data
+# For alternate reading data
 VARIANT = 'variant'
 EMENDATION = 'emendation'
 RECONSTRUCTION = 'reconstruction'
 CONCORDANCE = 'concordance'
 BLANK = 'blank'
 IGNORED = 'ignored'
+ORIGINAL_OR_UNKNOWN = 'original'
 
 # Color data
 ANYCOLOR = 'ANYCOLOR'

--- a/massage/transform/ficta.py
+++ b/massage/transform/ficta.py
@@ -1,0 +1,39 @@
+from constants import *
+from pymei import MeiElement
+
+
+def mark_ficta(MEI_tree, color_we_want):
+    """If a staff is not an emendation, reconstruction, etc.,
+    change colored notes with accidentals into ficta.
+    """
+    all_measures = MEI_tree.getDescendantsByName('measure')
+    for measure in all_measures:
+        for staff in measure:
+            if staff_role(staff) == ORIGINAL_OR_UNKNOWN:
+                notes_in_staff = staff.getDescendantsByName('note')
+                for note in notes:
+                    if color_matches(get_color(note), color_we_want):
+                        mark_accid_as_editorial(note)
+
+def mark_accid_as_editorial(note):
+    """If the note given has an accidental, mark that accidental
+    as editorial and display it above the note.
+    """
+    # There should be zero or one accid elements in the list,
+    # but it's easier and maybe safer to get a list of "all"
+    # the accidental elements contained within the note.
+    note_accidentals = note.getDescendantsByName('accid')
+    for accid in note_accidentals:
+        supplied_element = MeiElement('supplied')
+        supplied_element.addAttribute('reason', 'edit')
+        note.addChild(supplied_element)
+
+        accid.addAttribute('func', 'edit')
+        accid.addAttribute('place', 'above')
+        # The accidental SHOULD be the child of <note>, but
+        # just in case we'll get its parent.
+        accid_parent = accid.getParent()
+        accid_parent.removeChild(accid)
+        # Then add the <accid> element to <supplied>
+        supplied_element.addChild(accid)
+        

--- a/massage/transform/ficta.py
+++ b/massage/transform/ficta.py
@@ -1,4 +1,5 @@
 from constants import *
+from alt import color_matches
 from pymei import MeiElement
 
 

--- a/massage/transform/transform.py
+++ b/massage/transform/transform.py
@@ -17,6 +17,7 @@ from remove_elements import cleanup_all_elements
 from remove_attributes import cleanup_all_attributes
 from invisible import make_invisible_space
 from copyright import use_restrict
+from ficta import mark_ficta
 
 from constants import *
 from utilities import source_name2NCName
@@ -26,6 +27,8 @@ import logging
 
 
 class TransformData:
+    # If you do not want to run the ficta function, use
+    # `ficta=False` rather than `ficta=ANYCOLOR`.
     def __init__(self,
             alternates_list=[],
             arranger_to_editor=False,
@@ -39,6 +42,7 @@ class TransformData:
             make_invisible_space=True,
             copyright_text=None,
             cleanup=True,
+            ficta=ANYCOLOR,
         ):
         # The alternates_list field contains information about variants,
         # emendations and reconstructions. It is a list of 4-tuples.
@@ -86,6 +90,7 @@ def transform(MEI_doc, data=TransformData()):
     logging.info('editorial_resp: ' + str(data.editorial_resp))
     logging.info('color_for_variants: ' + str(data.color_for_variants))
     logging.info('color_for_emendations: ' + str(data.color_for_emendations))
+    logging.info('color_for_ficta: ' + str(data.color_for_ficta))
     MEI_tree = MEI_doc.getRootElement()
     data.alternates_list = validate_ncnames(data.alternates_list)
     orig_clefs(MEI_tree, data.alternates_list)
@@ -115,6 +120,8 @@ def transform(MEI_doc, data=TransformData()):
     responsibility(MEI_tree, data.editorial_resp)
 
     # Only now should we do the tricky stuff.
+    if data.ficta:
+        mark_ficta(MEI_tree, data.ficta)
     sources_and_editors(MEI_tree, data.alternates_list)
     variants(MEI_tree, data.alternates_list, data.color_for_variants)
     emendations(MEI_tree, data.alternates_list, data.color_for_emendations)


### PR DESCRIPTION
This function:
- seeks out staves that aren't reconstructions, emendations, etc.
- finds notes that are colored
- takes any &lt;accid&gt; elements that are in that colored note and marks them as editorial ficta above the note
